### PR TITLE
use command "magick" because "convert" doesn't seem to work

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,9 @@ const applyCrop = (pngFilePath, coordinates = { width: 0, height: 0, x: 0, y: 0 
 
 const pdfToPng = (pdfFilePath, pngFilePath, config) => {
     return new Promise((resolve, reject) => {
+        const command = process.platform === "win32" ? "magick" : "convert";
         gm(pdfFilePath)
-            .command("magick")
+            .command(command)
             .density(config.settings.density, config.settings.density)
             .quality(config.settings.quality)
             .write(pngFilePath, (err) => {

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ const applyCrop = (pngFilePath, coordinates = { width: 0, height: 0, x: 0, y: 0 
 const pdfToPng = (pdfFilePath, pngFilePath, config) => {
     return new Promise((resolve, reject) => {
         gm(pdfFilePath)
+            .command("magick")
             .density(config.settings.density, config.settings.density)
             .quality(config.settings.quality)
             .write(pngFilePath, (err) => {


### PR DESCRIPTION
Please consider this small change to your project.

After installing the newest version of the system dependencies, I found the "convert" command to not be working on its own with ImageMagick Q8 v7.0.10-3.

Using "magick convert" or simply "magick" fixed my issue.

Thanks for your work.