### PR TITLE
Fix usage of graphicsMagick image engine on win32 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Standalone node module that compares pdfs
 
 ## Setup
 
-To use GraphicsMagick (gm) Engine, install the following system dependencies 
+To use GraphicsMagick (gm) Engine, install the following system dependencies
+
+On MS Windows, please use the 32bit version of GhostScript
 
 -   [GraphicsMagick](http://www.graphicsmagick.org/README.html)
 -   [ImageMagick](https://imagemagick.org/script/download.php)

--- a/functions/comparePdf.js
+++ b/functions/comparePdf.js
@@ -46,7 +46,6 @@ class ComparePdf {
 	}
 
 	baselinePdfFile(baselinePdf) {
-        console.log("ComparePdf ~ baselinePdf", baselinePdf);
 		if (baselinePdf) {
 			const baselinePdfBaseName = path.parse(baselinePdf).name;
 			if (fs.existsSync(baselinePdf)) {

--- a/functions/engines/graphicsMagick.js
+++ b/functions/engines/graphicsMagick.js
@@ -19,7 +19,9 @@ const pdfToPng = (pdfDetails, pngFilePath, config) => {
 
 const applyMask = (pngFilePath, coordinates = { x0: 0, y0: 0, x1: 0, y1: 0 }, color = 'black') => {
 	return new Promise((resolve, reject) => {
+		const command = process.platform === 'win32' ? 'magick' : 'convert';
 		gm(pngFilePath)
+			.command(command)
 			.drawRectangle(coordinates.x0, coordinates.y0, coordinates.x1, coordinates.y1)
 			.fill(color)
 			.write(pngFilePath, (err) => {
@@ -30,7 +32,9 @@ const applyMask = (pngFilePath, coordinates = { x0: 0, y0: 0, x1: 0, y1: 0 }, co
 
 const applyCrop = (pngFilePath, coordinates = { width: 0, height: 0, x: 0, y: 0 }, index = 0) => {
 	return new Promise((resolve, reject) => {
+		const command = process.platform === 'win32' ? 'magick' : 'convert';
 		gm(pngFilePath)
+			.command(command)
 			.crop(coordinates.width, coordinates.height, coordinates.x, coordinates.y)
 			.write(pngFilePath.replace('.png', `-${index}.png`), (err) => {
 				err ? reject(err) : resolve();


### PR DESCRIPTION
Updated README.md, indicating you should only use 32bit version of GhostScript on win32 platforms
Removed debugging console.log message in comparePdf.js
Added command to applyMask and applyCrop in graphicsMagick.js for running on win32 platforms