### PR TITLE
added devDependency @prettier/plugin-xml v2.2.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+	"plugins": ["prettier"],
+	"extends": ["plugin:prettier/recommended"],
+	"env": {
+		"node": true,
+		"es6": true,
+		"browser": true
+	},
+	"ignorePatterns": ["examples/cypress/cypress/support/index.js"],
+	"rules": {
+		"no-unused-vars": "off",
+		"semi": "error",
+		"no-console": "off",
+		"quote-props": ["error", "always"],
+		"prettier/prettier": "error"
+	},
+	"parserOptions": {
+		"ecmaVersion": 2021
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 package-lock.json
 **/*.png
 .git
+
+# Husky
+.husky/_

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+# Project
+.eslintcache
+.husky/
+.idea/
+node_modules
+package-lock.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,16 @@
+{
+	"arrowParens": "always",
+	"bracketSpacing": true,
+	"quoteProps": "preserve",
+	"semi": true,
+	"singleQuote": true,
+	"tabWidth": 2,
+	"trailingComma": "none",
+	"useTabs": true,
+	"overrides": [
+		{
+			"files": "*.json",
+			"options": { "parser": "json" }
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ Standalone node module that compares pdfs
 
 To use GraphicsMagick (gm) Engine, install the following system dependencies
 
-On MS Windows, please use the 32bit version of GhostScript
-
 -   [GraphicsMagick](http://www.graphicsmagick.org/README.html)
--   [ImageMagick](https://imagemagick.org/script/download.php)
+-   [ImageMagick >=7](https://imagemagick.org/script/download.php)
 -   [GhostScript](https://www.ghostscript.com/download.html)
 
 ```

--- a/examples/cypress/config.js
+++ b/examples/cypress/config.js
@@ -1,15 +1,15 @@
 module.exports = {
-    paths: {
-        actualPdfRootFolder: process.cwd() + "/testData/pdf/actual",
-        baselinePdfRootFolder: process.cwd() + "/testData/pdf/baseline",
-        actualPngRootFolder: process.cwd() + "/testData/png/actual",
-        baselinePngRootFolder: process.cwd() + "/testData/png/baseline",
-        diffPngRootFolder: process.cwd() + "/testData/png/diff"
-    },
-    settings: {
-        density: 150,
-        quality: 80,
-        tolerance: 0,
-        threshold: 0.1
-    }
+	'paths': {
+		'actualPdfRootFolder': process.cwd() + '/testData/pdf/actual',
+		'baselinePdfRootFolder': process.cwd() + '/testData/pdf/baseline',
+		'actualPngRootFolder': process.cwd() + '/testData/png/actual',
+		'baselinePngRootFolder': process.cwd() + '/testData/png/baseline',
+		'diffPngRootFolder': process.cwd() + '/testData/png/diff'
+	},
+	'settings': {
+		'density': 150,
+		'quality': 80,
+		'tolerance': 0,
+		'threshold': 0.1
+	}
 };

--- a/examples/cypress/cypress.json
+++ b/examples/cypress/cypress.json
@@ -1,3 +1,3 @@
 {
-    "defaultCommandTimeout": 60000
+	"defaultCommandTimeout": 60000
 }

--- a/examples/cypress/cypress/fixtures/example.json
+++ b/examples/cypress/cypress/fixtures/example.json
@@ -1,5 +1,5 @@
 {
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
+	"name": "Using fixtures to represent data",
+	"email": "hello@cypress.io",
+	"body": "Fixtures are a great way to mock data for responses to routes"
 }

--- a/examples/cypress/cypress/integration/examplePdfTest.js
+++ b/examples/cypress/cypress/integration/examplePdfTest.js
@@ -1,12 +1,12 @@
-describe("ToDo React", () => {
-    before(() => {});
+describe('ToDo React', () => {
+	before(() => {});
 
-    it("should show the correct page title", async () => {
-        cy.task("pdfCompare", {
-            actualPdf: "actualPdf.pdf",
-            baselinePdf: "baselinePdf.pdf"
-        }).then((result) => {
-            expect(result.status).to.equal("passed");
-        });
-    });
+	it('should show the correct page title', async () => {
+		cy.task('pdfCompare', {
+			'actualPdf': 'actualPdf.pdf',
+			'baselinePdf': 'baselinePdf.pdf'
+		}).then((result) => {
+			expect(result.status).to.equal('passed');
+		});
+	});
 });

--- a/examples/cypress/cypress/plugins/index.js
+++ b/examples/cypress/cypress/plugins/index.js
@@ -11,17 +11,17 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const comparePdf = require("compare-pdf");
+const comparePdf = require('compare-pdf');
 module.exports = (on, config) => {
-    // `on` is used to hook into various events Cypress emits
-    // `config` is the resolved Cypress config
-    on("task", {
-        async pdfCompare({ actualPdf, baselinePdf }) {
-            let comparisonResults = await new comparePdf()
-                .actualPdfFile(actualPdf)
-                .baselinePdfFile(baselinePdf)
-                .compare();
-            return comparisonResults;
-        }
-    });
+	// `on` is used to hook into various events Cypress emits
+	// `config` is the resolved Cypress config
+	on('task', {
+		async pdfCompare({ actualPdf, baselinePdf }) {
+			let comparisonResults = await new comparePdf()
+				.actualPdfFile(actualPdf)
+				.baselinePdfFile(baselinePdf)
+				.compare();
+			return comparisonResults;
+		}
+	});
 };

--- a/examples/cypress/cypress/support/index.js
+++ b/examples/cypress/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/examples/cypress/package.json
+++ b/examples/cypress/package.json
@@ -1,13 +1,13 @@
 {
-    "name": "compare-pdf-examples-cypress",
-    "version": "1.0.0",
-    "description": "Example usage of compare-pdf in cypress",
-    "author": "Marc Dacanay",
-    "scripts": {
-        "test": "node_modules/.bin/cypress run"
-    },
-    "dependencies": {
-        "compare-pdf": "^1.0.4",
-        "cypress": "^3.7.0"
-    }
+	"name": "compare-pdf-examples-cypress",
+	"version": "1.0.0",
+	"description": "Example usage of compare-pdf in cypress",
+	"author": "Marc Dacanay",
+	"scripts": {
+		"test": "node_modules/.bin/cypress run"
+	},
+	"dependencies": {
+		"compare-pdf": "^1.0.4",
+		"cypress": "^3.7.0"
+	}
 }

--- a/examples/mocha/config.js
+++ b/examples/mocha/config.js
@@ -1,15 +1,15 @@
 module.exports = {
-    paths: {
-        actualPdfRootFolder: process.cwd() + "/testData/pdf/actual",
-        baselinePdfRootFolder: process.cwd() + "/testData/pdf/baseline",
-        actualPngRootFolder: process.cwd() + "/testData/png/actual",
-        baselinePngRootFolder: process.cwd() + "/testData/png/baseline",
-        diffPngRootFolder: process.cwd() + "/testData/png/diff"
-    },
-    settings: {
-        density: 150,
-        quality: 80,
-        tolerance: 0,
-        threshold: 0.1
-    }
+	'paths': {
+		'actualPdfRootFolder': process.cwd() + '/testData/pdf/actual',
+		'baselinePdfRootFolder': process.cwd() + '/testData/pdf/baseline',
+		'actualPngRootFolder': process.cwd() + '/testData/png/actual',
+		'baselinePngRootFolder': process.cwd() + '/testData/png/baseline',
+		'diffPngRootFolder': process.cwd() + '/testData/png/diff'
+	},
+	'settings': {
+		'density': 150,
+		'quality': 80,
+		'tolerance': 0,
+		'threshold': 0.1
+	}
 };

--- a/examples/mocha/package.json
+++ b/examples/mocha/package.json
@@ -1,15 +1,15 @@
 {
-    "name": "compare-pdf-examples-mocha",
-    "version": "1.0.0",
-    "description": "Example usage of compare-pdf in mocha + chai",
-    "author": "Marc Dacanay",
-    "scripts": {
-        "mocha": "node ./node_modules/mocha/bin/mocha",
-        "test": "mocha --recursive --timeout 600000"
-    },
-    "dependencies": {
-        "chai": "^4.2.0",
-        "compare-pdf": "^1.0.4",
-        "mocha": "^6.2.2"
-    }
+	"name": "compare-pdf-examples-mocha",
+	"version": "1.0.0",
+	"description": "Example usage of compare-pdf in mocha + chai",
+	"author": "Marc Dacanay",
+	"scripts": {
+		"mocha": "node ./node_modules/mocha/bin/mocha",
+		"test": "mocha --recursive --timeout 600000"
+	},
+	"dependencies": {
+		"chai": "^4.2.0",
+		"compare-pdf": "^1.0.4",
+		"mocha": "^6.2.2"
+	}
 }

--- a/examples/mocha/test/examplePdfTest.js
+++ b/examples/mocha/test/examplePdfTest.js
@@ -1,22 +1,22 @@
-const comparePdf = require("compare-pdf");
-const chai = require("chai");
+const comparePdf = require('compare-pdf');
+const chai = require('chai');
 const expect = chai.expect;
-const config = require("../config");
+const config = require('../config');
 
-describe("Compare Pdf Tests in Mocha + Chai", () => {
-    it("Should be able to compare pdfs by image", async () => {
-        let comparisonResults = await new comparePdf(config)
-            .actualPdfFile("actualPdf")
-            .baselinePdfFile("baselinePdf")
-            .compare();
-        expect(comparisonResults.status).to.equal("passed");
-    });
+describe('Compare Pdf Tests in Mocha + Chai', () => {
+	it('Should be able to compare pdfs by image', async () => {
+		let comparisonResults = await new comparePdf(config)
+			.actualPdfFile('actualPdf')
+			.baselinePdfFile('baselinePdf')
+			.compare();
+		expect(comparisonResults.status).to.equal('passed');
+	});
 
-    it("Should be able to compare pdfs by base64", async () => {
-        let comparisonResults = await new comparePdf(config)
-            .actualPdfFile("actualPdf")
-            .baselinePdfFile("baselinePdf")
-            .compare("byBase64");
-        expect(comparisonResults.status).to.equal("passed");
-    });
+	it('Should be able to compare pdfs by base64', async () => {
+		let comparisonResults = await new comparePdf(config)
+			.actualPdfFile('actualPdf')
+			.baselinePdfFile('baselinePdf')
+			.compare('byBase64');
+		expect(comparisonResults.status).to.equal('passed');
+	});
 });

--- a/functions/compareData.js
+++ b/functions/compareData.js
@@ -1,29 +1,28 @@
-const fs = require("fs-extra");
-const path = require("path");
+const path = require('path');
 
 const comparePdfByBase64 = async (compareDetails) => {
-    const actualPdfFilename = compareDetails.actualPdfFilename;
-    const baselinePdfFilename = compareDetails.baselinePdfFilename;
-    const actualPdfBuffer = compareDetails.actualPdfBuffer;
-    const baselinePdfBuffer = compareDetails.baselinePdfBuffer;
-			
-    return new Promise(async (resolve, reject) => {
-        const actualPdfBaseName = path.parse(actualPdfFilename).name;
-        const baselinePdfBaseName = path.parse(baselinePdfFilename).name;
-        const actualPdfBase64 = Buffer.from(actualPdfBuffer).toString("base64");
-        const baselinePdfBase64 = Buffer.from(baselinePdfBuffer).toString("base64");
-        
-        if (actualPdfBase64 !== baselinePdfBase64) {
-            resolve({
-                status: "failed",
-                message: `${actualPdfBaseName}.pdf is not the same as ${baselinePdfBaseName}.pdf compared by their base64 values.`,
-            });
-        } else {
-            resolve({ status: "passed" });
-        }
-    });
+	const actualPdfFilename = compareDetails.actualPdfFilename;
+	const baselinePdfFilename = compareDetails.baselinePdfFilename;
+	const actualPdfBuffer = compareDetails.actualPdfBuffer;
+	const baselinePdfBuffer = compareDetails.baselinePdfBuffer;
+
+	return new Promise(async (resolve) => {
+		const actualPdfBaseName = path.parse(actualPdfFilename).name;
+		const baselinePdfBaseName = path.parse(baselinePdfFilename).name;
+		const actualPdfBase64 = Buffer.from(actualPdfBuffer).toString('base64');
+		const baselinePdfBase64 = Buffer.from(baselinePdfBuffer).toString('base64');
+
+		if (actualPdfBase64 !== baselinePdfBase64) {
+			resolve({
+				'status': 'failed',
+				'message': `${actualPdfBaseName}.pdf is not the same as ${baselinePdfBaseName}.pdf compared by their base64 values.`
+			});
+		} else {
+			resolve({ 'status': 'passed' });
+		}
+	});
 };
 
 module.exports = {
-    comparePdfByBase64,
+	comparePdfByBase64
 };

--- a/functions/compareImages.js
+++ b/functions/compareImages.js
@@ -6,34 +6,51 @@ const pixelmatch = require('pixelmatch');
 const utils = require('./utils');
 
 const comparePngs = async (actual, baseline, diff, config) => {
-	return new Promise((resolve, reject) => {
+	return new Promise((resolve) => {
 		try {
 			const actualPng = PNG.sync.read(fs.readFileSync(actual));
 			const baselinePng = PNG.sync.read(fs.readFileSync(baseline));
 			const { width, height } = actualPng;
 			const diffPng = new PNG({ width, height });
 
-			let threshold = config.settings && config.settings.threshold ? config.settings.threshold : 0.05;
-			let tolerance = config.settings && config.settings.tolerance ? config.settings.tolerance : 0;
+			let threshold =
+				config.settings && config.settings.threshold
+					? config.settings.threshold
+					: 0.05;
+			let tolerance =
+				config.settings && config.settings.tolerance
+					? config.settings.tolerance
+					: 0;
 
-			let numDiffPixels = pixelmatch(actualPng.data, baselinePng.data, diffPng.data, width, height, {
-				threshold: threshold
-			});
+			let numDiffPixels = pixelmatch(
+				actualPng.data,
+				baselinePng.data,
+				diffPng.data,
+				width,
+				height,
+				{
+					'threshold': threshold
+				}
+			);
 
 			if (numDiffPixels > tolerance) {
 				fs.writeFileSync(diff, PNG.sync.write(diffPng));
-				resolve({ status: 'failed', numDiffPixels: numDiffPixels, diffPng: diff });
+				resolve({
+					'status': 'failed',
+					'numDiffPixels': numDiffPixels,
+					'diffPng': diff
+				});
 			} else {
-				resolve({ status: 'passed' });
+				resolve({ 'status': 'passed' });
 			}
 		} catch (error) {
-			resolve({ status: 'failed', actual: actual, error: error });
+			resolve({ 'status': 'failed', 'actual': actual, 'error': error });
 		}
 	});
 };
 
 const comparePdfByImage = async (compareDetails) => {
-	return new Promise(async (resolve, reject) => {
+	return new Promise(async (resolve) => {
 		try {
 			const actualPdfFilename = compareDetails.actualPdfFilename;
 			const baselinePdfFilename = compareDetails.baselinePdfFilename;
@@ -50,42 +67,69 @@ const comparePdfByImage = async (compareDetails) => {
 			const actualPdfBaseName = path.parse(actualPdfFilename).name;
 			const baselinePdfBaseName = path.parse(baselinePdfFilename).name;
 
-			if (config.paths.actualPngRootFolder && config.paths.baselinePngRootFolder && config.paths.diffPngRootFolder) {
-				const actualPngDirPath = `${config.paths.actualPngRootFolder}/${actualPdfBaseName}`;
-				const baselinePngDirPath = `${config.paths.baselinePngRootFolder}/${baselinePdfBaseName}`;
-				const diffPngDirPath = `${config.paths.diffPngRootFolder}/${actualPdfBaseName}`;
+			if (
+				config.paths.actualPngRootFolder &&
+				config.paths.baselinePngRootFolder &&
+				config.paths.diffPngRootFolder
+			) {
+				const actualPngDirPath = path.resolve(
+					config.paths.actualPngRootFolder,
+					`${actualPdfBaseName}`
+				);
+				const baselinePngDirPath = path.resolve(
+					config.paths.baselinePngRootFolder,
+					`${baselinePdfBaseName}`
+				);
+				const diffPngDirPath = path.resolve(
+					config.paths.diffPngRootFolder,
+					`${actualPdfBaseName}`
+				);
 
 				utils.ensureAndCleanupPath(actualPngDirPath);
 				utils.ensureAndCleanupPath(baselinePngDirPath);
 				utils.ensureAndCleanupPath(diffPngDirPath);
 
-				const actualPngFilePath = `${actualPngDirPath}/${actualPdfBaseName}.png`;
-				const baselinePngFilePath = `${baselinePngDirPath}/${baselinePdfBaseName}.png`;
+				const actualPngFilePath = path.resolve(
+					actualPngDirPath,
+					`${actualPdfBaseName}.png`
+				);
+				const baselinePngFilePath = path.resolve(
+					baselinePngDirPath,
+					`${baselinePdfBaseName}.png`
+				);
 
 				const actualPdfDetails = {
-					filename: actualPdfFilename,
-					buffer: actualPdfBuffer
-				}
+					'filename': actualPdfFilename,
+					'buffer': actualPdfBuffer
+				};
 				await imageEngine.pdfToPng(actualPdfDetails, actualPngFilePath, config);
 
 				const baselinePdfDetails = {
-					filename: baselinePdfFilename,
-					buffer: baselinePdfBuffer
-				}
-				await imageEngine.pdfToPng(baselinePdfDetails, baselinePngFilePath, config);
+					'filename': baselinePdfFilename,
+					'buffer': baselinePdfBuffer
+				};
+				await imageEngine.pdfToPng(
+					baselinePdfDetails,
+					baselinePngFilePath,
+					config
+				);
 
 				let actualPngs = fs
 					.readdirSync(actualPngDirPath)
-					.filter((pngFile) => path.parse(pngFile).name.startsWith(actualPdfBaseName));
+					.filter((pngFile) =>
+						path.parse(pngFile).name.startsWith(actualPdfBaseName)
+					);
 				let baselinePngs = fs
 					.readdirSync(baselinePngDirPath)
-					.filter((pngFile) => path.parse(pngFile).name.startsWith(baselinePdfBaseName));
+					.filter((pngFile) =>
+						path.parse(pngFile).name.startsWith(baselinePdfBaseName)
+					);
 
 				if (config.settings.matchPageCount === true) {
 					if (actualPngs.length !== baselinePngs.length) {
 						resolve({
-							status: 'failed',
-							message: `Actual pdf page count (${actualPngs.length}) is not the same as Baseline pdf (${baselinePngs.length}).`
+							'status': 'failed',
+							'message': `Actual pdf page count (${actualPngs.length}) is not the same as Baseline pdf (${baselinePngs.length}).`
 						});
 					}
 				}
@@ -96,10 +140,22 @@ const comparePdfByImage = async (compareDetails) => {
 					if (baselinePngs.length > 1) {
 						suffix = `-${index}`;
 					}
-					//Change for issue-27		
-					let actualPng = actualPngs.length>1?`${actualPngDirPath}/${actualPdfBaseName}${suffix}.png`:`${actualPngDirPath}/${actualPdfBaseName}.png`;
-					let baselinePng = `${baselinePngDirPath}/${baselinePdfBaseName}${suffix}.png`;
-					let diffPng = `${diffPngDirPath}/${actualPdfBaseName}_diff${suffix}.png`;
+					//Change for issue-27
+					let actualPng =
+						actualPngs.length > 1
+							? path.resolve(
+									actualPngDirPath,
+									`${actualPdfBaseName}${suffix}.png`
+							  )
+							: path.resolve(actualPngDirPath, `${actualPdfBaseName}.png`);
+					let baselinePng = path.resolve(
+						baselinePngDirPath,
+						`${baselinePdfBaseName}${suffix}.png`
+					);
+					let diffPng = path.resolve(
+						diffPngDirPath,
+						`${actualPdfBaseName}_diff${suffix}.png`
+					);
 
 					if (opts.skipPageIndexes && opts.skipPageIndexes.length > 0) {
 						if (opts.skipPageIndexes.includes(index)) {
@@ -114,21 +170,41 @@ const comparePdfByImage = async (compareDetails) => {
 					}
 
 					if (opts.masks) {
-						let pageMasks = _.filter(opts.masks, { pageIndex: index });
+						let pageMasks = _.filter(opts.masks, { 'pageIndex': index });
 						if (pageMasks && pageMasks.length > 0) {
 							for (const pageMask of pageMasks) {
-								await imageEngine.applyMask(actualPng, pageMask.coordinates, pageMask.color);
-								await imageEngine.applyMask(baselinePng, pageMask.coordinates, pageMask.color);
+								await imageEngine.applyMask(
+									actualPng,
+									pageMask.coordinates,
+									pageMask.color
+								);
+								await imageEngine.applyMask(
+									baselinePng,
+									pageMask.coordinates,
+									pageMask.color
+								);
 							}
 						}
 					}
 
 					if (opts.crops && opts.crops.length > 0) {
-						let pageCroppings = _.filter(opts.crops, { pageIndex: index });
+						let pageCroppings = _.filter(opts.crops, { 'pageIndex': index });
 						if (pageCroppings && pageCroppings.length > 0) {
-							for (let cropIndex = 0; cropIndex < pageCroppings.length; cropIndex++) {
-								await imageEngine.applyCrop(actualPng, pageCroppings[cropIndex].coordinates, cropIndex);
-								await imageEngine.applyCrop(baselinePng, pageCroppings[cropIndex].coordinates, cropIndex);
+							for (
+								let cropIndex = 0;
+								cropIndex < pageCroppings.length;
+								cropIndex++
+							) {
+								await imageEngine.applyCrop(
+									actualPng,
+									pageCroppings[cropIndex].coordinates,
+									cropIndex
+								);
+								await imageEngine.applyCrop(
+									baselinePng,
+									pageCroppings[cropIndex].coordinates,
+									cropIndex
+								);
 								comparisonResults.push(
 									await comparePngs(
 										actualPng.replace('.png', `-${cropIndex}.png`),
@@ -140,7 +216,9 @@ const comparePdfByImage = async (compareDetails) => {
 							}
 						}
 					} else {
-						comparisonResults.push(await comparePngs(actualPng, baselinePng, diffPng, config));
+						comparisonResults.push(
+							await comparePngs(actualPng, baselinePng, diffPng, config)
+						);
 					}
 				}
 
@@ -149,29 +227,31 @@ const comparePdfByImage = async (compareDetails) => {
 					utils.ensureAndCleanupPath(config.paths.baselinePngRootFolder);
 				}
 
-				const failedResults = _.filter(comparisonResults, (res) => res.status === 'failed');
+				const failedResults = _.filter(
+					comparisonResults,
+					(res) => res.status === 'failed'
+				);
 				if (failedResults.length > 0) {
 					resolve({
-						status: 'failed',
-						message: `${actualPdfBaseName}.pdf is not the same as ${baselinePdfBaseName}.pdf compared by their images.`,
-						details: failedResults
+						'status': 'failed',
+						'message': `${actualPdfBaseName}.pdf is not the same as ${baselinePdfBaseName}.pdf compared by their images.`,
+						'details': failedResults
 					});
-				} else {					
-					resolve({ status: 'passed' });
+				} else {
+					resolve({ 'status': 'passed' });
 				}
 			} else {
 				resolve({
-					status: 'failed',
-					message: `PNG directory is not set. Please define correctly then try again.`
+					'status': 'failed',
+					'message': `PNG directory is not set. Please define correctly then try again.`
 				});
 			}
 		} catch (error) {
 			resolve({
-				status: 'failed',
-				message: `An error occurred.\n${error}`
+				'status': 'failed',
+				'message': `An error occurred.\n${error}`
 			});
 		}
-
 	});
 };
 

--- a/functions/comparePdf.js
+++ b/functions/comparePdf.js
@@ -10,14 +10,14 @@ class ComparePdf {
 		utils.ensurePathsExist(this.config);
 
 		this.opts = {
-			masks: [],
-			crops: [],
-			onlyPageIndexes: [],
-			skipPageIndexes: []
-		}
+			'masks': [],
+			'crops': [],
+			'onlyPageIndexes': [],
+			'skipPageIndexes': []
+		};
 
 		this.result = {
-			status: 'not executed'
+			'status': 'not executed'
 		};
 	}
 
@@ -29,8 +29,9 @@ class ComparePdf {
 			}
 		} else {
 			this.result = {
-				status: 'failed',
-				message: 'Baseline pdf buffer is invalid or filename is missing. Please define correctly then try again.'
+				'status': 'failed',
+				'message':
+					'Baseline pdf buffer is invalid or filename is missing. Please define correctly then try again.'
 			};
 		}
 		return this;
@@ -41,18 +42,30 @@ class ComparePdf {
 			const baselinePdfBaseName = path.parse(baselinePdf).name;
 			if (fs.existsSync(baselinePdf)) {
 				this.baselinePdf = baselinePdf;
-			} else if (fs.existsSync(`${this.config.paths.baselinePdfRootFolder}/${baselinePdfBaseName}.pdf`)) {
-				this.baselinePdf = `${this.config.paths.baselinePdfRootFolder}/${baselinePdfBaseName}.pdf`;
+			} else if (
+				fs.existsSync(
+					path.resolve(
+						this.config.paths.baselinePdfRootFolder,
+						`${baselinePdfBaseName}.pdf`
+					)
+				)
+			) {
+				this.baselinePdf = path.resolve(
+					this.config.paths.baselinePdfRootFolder,
+					`${baselinePdfBaseName}.pdf`
+				);
 			} else {
 				this.result = {
-					status: 'failed',
-					message: 'Baseline pdf file path does not exists. Please define correctly then try again.'
+					'status': 'failed',
+					'message':
+						'Baseline pdf file path does not exists. Please define correctly then try again.'
 				};
 			}
 		} else {
 			this.result = {
-				status: 'failed',
-				message: 'Baseline pdf file path was not set. Please define correctly then try again.'
+				'status': 'failed',
+				'message':
+					'Baseline pdf file path was not set. Please define correctly then try again.'
 			};
 		}
 		return this;
@@ -66,8 +79,9 @@ class ComparePdf {
 			}
 		} else {
 			this.result = {
-				status: 'failed',
-				message: 'Actual pdf buffer is invalid or filename is missing. Please define correctly then try again.'
+				'status': 'failed',
+				'message':
+					'Actual pdf buffer is invalid or filename is missing. Please define correctly then try again.'
 			};
 		}
 		return this;
@@ -78,28 +92,44 @@ class ComparePdf {
 			const actualPdfBaseName = path.parse(actualPdf).name;
 			if (fs.existsSync(actualPdf)) {
 				this.actualPdf = actualPdf;
-			} else if (fs.existsSync(`${this.config.paths.actualPdfRootFolder}/${actualPdfBaseName}.pdf`)) {
-				this.actualPdf = `${this.config.paths.actualPdfRootFolder}/${actualPdfBaseName}.pdf`;
+			} else if (
+				fs.existsSync(
+					path.resolve(
+						this.config.paths.actualPdfRootFolder,
+						`${actualPdfBaseName}.pdf`
+					)
+				)
+			) {
+				this.actualPdf = path.resolve(
+					this.config.paths.actualPdfRootFolder,
+					`${actualPdfBaseName}.pdf`
+				);
 			} else {
 				this.result = {
-					status: 'failed',
-					message: 'Actual pdf file path does not exists. Please define correctly then try again.'
+					'status': 'failed',
+					'message':
+						'Actual pdf file path does not exists. Please define correctly then try again.'
 				};
 			}
 		} else {
 			this.result = {
-				status: 'failed',
-				message: 'Actual pdf file path was not set. Please define correctly then try again.'
+				'status': 'failed',
+				'message':
+					'Actual pdf file path was not set. Please define correctly then try again.'
 			};
 		}
 		return this;
 	}
 
-	addMask(pageIndex, coordinates = { x0: 0, y0: 0, x1: 0, y1: 0 }, color = 'black') {
+	addMask(
+		pageIndex,
+		coordinates = { 'x0': 0, 'y0': 0, 'x1': 0, 'y1': 0 },
+		color = 'black'
+	) {
 		this.opts.masks.push({
-			pageIndex: pageIndex,
-			coordinates: coordinates,
-			color: color
+			'pageIndex': pageIndex,
+			'coordinates': coordinates,
+			'color': color
 		});
 		return this;
 	}
@@ -119,10 +149,13 @@ class ComparePdf {
 		return this;
 	}
 
-	cropPage(pageIndex, coordinates = { width: 0, height: 0, x: 0, y: 0 }) {
+	cropPage(
+		pageIndex,
+		coordinates = { 'width': 0, 'height': 0, 'x': 0, 'y': 0 }
+	) {
 		this.opts.crops.push({
-			pageIndex: pageIndex,
-			coordinates: coordinates
+			'pageIndex': pageIndex,
+			'coordinates': coordinates
 		});
 		return this;
 	}
@@ -133,15 +166,22 @@ class ComparePdf {
 	}
 
 	async compare(comparisonType = 'byImage') {
-		if (this.result.status === 'not executed' || this.result.status !== 'failed') {
+		if (
+			this.result.status === 'not executed' ||
+			this.result.status !== 'failed'
+		) {
 			const compareDetails = {
-				actualPdfFilename: this.actualPdf,
-				baselinePdfFilename: this.baselinePdf,
-				actualPdfBuffer: this.actualPdfBufferData ? this.actualPdfBufferData : fs.readFileSync(this.actualPdf), //, { encoding: "base64" }
-				baselinePdfBuffer: this.baselinePdfBufferData ? this.baselinePdfBufferData : fs.readFileSync(this.baselinePdf),
-				config: this.config,
-				opts: this.opts
-			}
+				'actualPdfFilename': this.actualPdf,
+				'baselinePdfFilename': this.baselinePdf,
+				'actualPdfBuffer': this.actualPdfBufferData
+					? this.actualPdfBufferData
+					: fs.readFileSync(this.actualPdf), //, { encoding: "base64" }
+				'baselinePdfBuffer': this.baselinePdfBufferData
+					? this.baselinePdfBufferData
+					: fs.readFileSync(this.baselinePdf),
+				'config': this.config,
+				'opts': this.opts
+			};
 			switch (comparisonType) {
 				case 'byBase64':
 					this.result = await compareData.comparePdfByBase64(compareDetails);

--- a/functions/config.js
+++ b/functions/config.js
@@ -1,20 +1,20 @@
 module.exports = {
-	paths: {
-		actualPdfRootFolder: process.cwd() + '/data/actualPdfs',
-		baselinePdfRootFolder: process.cwd() + '/data/baselinePdfs',
-		actualPngRootFolder: process.cwd() + '/data/actualPngs',
-		baselinePngRootFolder: process.cwd() + '/data/baselinePngs',
-		diffPngRootFolder: process.cwd() + '/data/diffPngs'
+	'paths': {
+		'actualPdfRootFolder': process.cwd() + '/data/actualPdfs',
+		'baselinePdfRootFolder': process.cwd() + '/data/baselinePdfs',
+		'actualPngRootFolder': process.cwd() + '/data/actualPngs',
+		'baselinePngRootFolder': process.cwd() + '/data/baselinePngs',
+		'diffPngRootFolder': process.cwd() + '/data/diffPngs'
 	},
-	settings: {
-		imageEngine: 'graphicsMagick',
-		density: 100,
-		quality: 70,
-		tolerance: 0,
-		threshold: 0.05,
-		cleanPngPaths: true,
-		matchPageCount: true,
-		disableFontFace: true,
-		verbosity: 0
+	'settings': {
+		'imageEngine': 'graphicsMagick',
+		'density': 100,
+		'quality': 70,
+		'tolerance': 0,
+		'threshold': 0.05,
+		'cleanPngPaths': true,
+		'matchPageCount': true,
+		'disableFontFace': true,
+		'verbosity': 0
 	}
 };

--- a/functions/engines/NodeCanvasFactory.js
+++ b/functions/engines/NodeCanvasFactory.js
@@ -9,8 +9,8 @@ class NodeCanvasFactory {
 		let canvas = Canvas.createCanvas(width, height);
 		let context = canvas.getContext('2d');
 		return {
-			canvas: canvas,
-			context: context
+			'canvas': canvas,
+			'context': context
 		};
 	}
 

--- a/functions/engines/graphicsMagick.js
+++ b/functions/engines/graphicsMagick.js
@@ -1,14 +1,13 @@
-const gm = require('gm').subClass({ imageMagick: true });
-const path = require("path");
+const gm = require('gm').subClass({ 'imageMagick': '7+' });
+const path = require('path');
 
 const pdfToPng = (pdfDetails, pngFilePath, config) => {
 	return new Promise((resolve, reject) => {
-		const command = process.platform === 'win32' ? 'magick' : 'convert';
 		const pdfBuffer = pdfDetails.buffer;
-		const pdfFilename = path.parse(pdfDetails.filename).name
+		const pdfFilename = path.parse(pdfDetails.filename).name;
 
 		gm(pdfBuffer, pdfFilename)
-			.command(command)
+			.command('convert')
 			.density(config.settings.density, config.settings.density)
 			.quality(config.settings.quality)
 			.write(pngFilePath, (err) => {
@@ -17,12 +16,20 @@ const pdfToPng = (pdfDetails, pngFilePath, config) => {
 	});
 };
 
-const applyMask = (pngFilePath, coordinates = { x0: 0, y0: 0, x1: 0, y1: 0 }, color = 'black') => {
+const applyMask = (
+	pngFilePath,
+	coordinates = { 'x0': 0, 'y0': 0, 'x1': 0, 'y1': 0 },
+	color = 'black'
+) => {
 	return new Promise((resolve, reject) => {
-		const command = process.platform === 'win32' ? 'magick' : 'convert';
 		gm(pngFilePath)
-			.command(command)
-			.drawRectangle(coordinates.x0, coordinates.y0, coordinates.x1, coordinates.y1)
+			.command('convert')
+			.drawRectangle(
+				coordinates.x0,
+				coordinates.y0,
+				coordinates.x1,
+				coordinates.y1
+			)
 			.fill(color)
 			.write(pngFilePath, (err) => {
 				err ? reject(err) : resolve();
@@ -30,11 +37,14 @@ const applyMask = (pngFilePath, coordinates = { x0: 0, y0: 0, x1: 0, y1: 0 }, co
 	});
 };
 
-const applyCrop = (pngFilePath, coordinates = { width: 0, height: 0, x: 0, y: 0 }, index = 0) => {
+const applyCrop = (
+	pngFilePath,
+	coordinates = { 'width': 0, 'height': 0, 'x': 0, 'y': 0 },
+	index = 0
+) => {
 	return new Promise((resolve, reject) => {
-		const command = process.platform === 'win32' ? 'magick' : 'convert';
 		gm(pngFilePath)
-			.command(command)
+			.command('convert')
 			.crop(coordinates.width, coordinates.height, coordinates.x, coordinates.y)
 			.write(pngFilePath.replace('.png', `-${index}.png`), (err) => {
 				err ? reject(err) : resolve();

--- a/functions/engines/native.js
+++ b/functions/engines/native.js
@@ -7,22 +7,32 @@ const CMAP_URL = '../../node_modules/pdfjs-dist/cmaps/';
 const CMAP_PACKED = true;
 const STANDARD_FONT_DATA_URL = '../../node_modules/pdfjs-dist/standard_fonts/';
 
-const pdfPageToPng = async (pdfDocument, pageNumber, filename, isSinglePage = false) => {
+const pdfPageToPng = async (
+	pdfDocument,
+	pageNumber,
+	filename,
+	isSinglePage = false
+) => {
 	try {
 		let page = await pdfDocument.getPage(pageNumber);
-		let viewport = page.getViewport({ scale: 1.38889 });
+		let viewport = page.getViewport({ 'scale': 1.38889 });
 		let canvasFactory = new NodeCanvasFactory();
-		let canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
+		let canvasAndContext = canvasFactory.create(
+			viewport.width,
+			viewport.height
+		);
 		let renderContext = {
-			canvasContext: canvasAndContext.context,
-			viewport: viewport,
-			canvasFactory: canvasFactory
+			'canvasContext': canvasAndContext.context,
+			'viewport': viewport,
+			'canvasFactory': canvasFactory
 		};
 
 		await page.render(renderContext).promise;
 
 		let image = canvasAndContext.canvas.toBuffer();
-		let pngFileName = isSinglePage ? filename : filename.replace('.png', `-${pageNumber - 1}.png`);
+		let pngFileName = isSinglePage
+			? filename
+			: filename.replace('.png', `-${pageNumber - 1}.png`);
 		fs.writeFileSync(pngFileName, image);
 	} catch (error) {
 		throw error;
@@ -33,24 +43,37 @@ const pdfToPng = async (pdfDetails, pngFilePath, config) => {
 	try {
 		const pdfData = new Uint8Array(pdfDetails.buffer);
 		const pdfDocument = await pdfjsLib.getDocument({
-			disableFontFace: config.settings.hasOwnProperty('disableFontFace') ? config.settings.disableFontFace : true,
-			data: pdfData,
-			cMapUrl: CMAP_URL,
-			cMapPacked: CMAP_PACKED,
-			standardFontDataUrl: STANDARD_FONT_DATA_URL,
-			verbosity: config.settings.hasOwnProperty('verbosity') ? config.settings.verbosity : 0
+			'disableFontFace': config.settings.hasOwnProperty('disableFontFace')
+				? config.settings.disableFontFace
+				: true,
+			'data': pdfData,
+			'cMapUrl': CMAP_URL,
+			'cMapPacked': CMAP_PACKED,
+			'standardFontDataUrl': STANDARD_FONT_DATA_URL,
+			'verbosity': config.settings.hasOwnProperty('verbosity')
+				? config.settings.verbosity
+				: 0
 		}).promise;
 
 		for (let index = 1; index <= pdfDocument.numPages; index++) {
-			await pdfPageToPng(pdfDocument, index, pngFilePath, pdfDocument.numPages === 1);
+			await pdfPageToPng(
+				pdfDocument,
+				index,
+				pngFilePath,
+				pdfDocument.numPages === 1
+			);
 		}
 	} catch (error) {
 		throw error;
 	}
 };
 
-const applyMask = (pngFilePath, coordinates = { x0: 0, y0: 0, x1: 0, y1: 0 }, color = 'black') => {
-	return new Promise((resolve, reject) => {
+const applyMask = (
+	pngFilePath,
+	coordinates = { 'x0': 0, 'y0': 0, 'x1': 0, 'y1': 0 },
+	color = 'black'
+) => {
+	return new Promise((resolve) => {
 		const data = fs.readFileSync(pngFilePath);
 		const img = new Canvas.Image();
 		img.src = data;
@@ -58,14 +81,23 @@ const applyMask = (pngFilePath, coordinates = { x0: 0, y0: 0, x1: 0, y1: 0 }, co
 		const ctx = canvas.getContext('2d');
 		ctx.drawImage(img, 0, 0, img.width, img.height);
 		ctx.beginPath();
-		ctx.fillRect(coordinates.x0, coordinates.y0, coordinates.x1 - coordinates.x0, coordinates.y1 - coordinates.y0);
+		ctx.fillRect(
+			coordinates.x0,
+			coordinates.y0,
+			coordinates.x1 - coordinates.x0,
+			coordinates.y1 - coordinates.y0
+		);
 		fs.writeFileSync(pngFilePath, canvas.toBuffer());
 		resolve();
 	});
 };
 
-const applyCrop = (pngFilePath, coordinates = { width: 0, height: 0, x: 0, y: 0 }, index = 0) => {
-	return new Promise((resolve, reject) => {
+const applyCrop = (
+	pngFilePath,
+	coordinates = { 'width': 0, 'height': 0, 'x': 0, 'y': 0 },
+	index = 0
+) => {
+	return new Promise((resolve) => {
 		const data = fs.readFileSync(pngFilePath);
 		const img = new Canvas.Image();
 		img.src = data;
@@ -83,7 +115,10 @@ const applyCrop = (pngFilePath, coordinates = { width: 0, height: 0, x: 0, y: 0 
 			coordinates.height
 		);
 
-		fs.writeFileSync(pngFilePath.replace('.png', `-${index}.png`), canvas.toBuffer());
+		fs.writeFileSync(
+			pngFilePath.replace('.png', `-${index}.png`),
+			canvas.toBuffer()
+		);
 		resolve();
 	});
 };

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
 	"main": "./functions/comparePdf",
 	"types": "./types/comparePdf.d.ts",
 	"scripts": {
+		"lint": "eslint . --fix",
 		"mocha": "node ./node_modules/mocha/bin/mocha",
+		"pretty": "prettier --write \"./**/*.{css,html,js,json}\"",
 		"test": "mocha --recursive --timeout 600000",
-		"test-ts": "env TS_NODE_PROJECT=\"tsconfig.testing.json\" mocha --recursive --timeout 600000 --require ts-node/register 'test/**/*.ts'"
+		"test-ts": "env TS_NODE_PROJECT=\"tsconfig.testing.json\" mocha --recursive --timeout 600000 --require ts-node/register 'test/**/*.ts'",
+		"prepare": "husky install"
 	},
 	"repository": {
 		"type": "git",
@@ -22,20 +25,32 @@
 		"test pdf"
 	],
 	"devDependencies": {
+		"@prettier/plugin-xml": "^2.2.0",
 		"@types/chai": "^4.3.1",
 		"@types/mocha": "^9.1.1",
 		"@types/node": "^18.0.0",
 		"chai": "^4.2.0",
-		"mocha": "^6.2.2",
+		"eslint": "^8.27.0",
+		"eslint-config-prettier": "^8.5.0",
+		"eslint-plugin-prettier": "^4.2.1",
+		"husky": "^8.0.1",
+		"lint-staged": "^13.0.3",
+		"mocha": "^10.1.0",
+		"prettier": "^2.7.1",
 		"ts-node": "^10.8.1"
 	},
 	"dependencies": {
 		"canvas": "^2.6.1",
-		"fs-extra": "^8.1.0",
-		"gm": "^1.23.1",
-		"lodash": "^4.17.15",
-		"pdfjs-dist": "^2.8.335",
+		"fs-extra": "^10.1.0",
+		"gm": "^1.25.0",
+		"lodash": "^4.17.21",
+		"pdfjs-dist": "^3.0.279",
 		"pixelmatch": "^5.1.0",
-		"pngjs": "^3.4.0"
+		"pngjs": "^6.0.0",
+		"typescript": "^4.8.4"
+	},
+	"lint-staged": {
+		"*.js": "eslint --cache --fix",
+		"*.{css,html,js,json}": "prettier --write"
 	}
 }

--- a/test/comparePdfTests.js
+++ b/test/comparePdfTests.js
@@ -3,7 +3,7 @@ const comparePdf = require('../.');
 const chai = require('chai');
 const expect = chai.expect;
 
- describe('Compare Pdf Common Tests', () => {
+describe('Compare Pdf Common Tests', () => {
 	it('Should be able to override default configs', async () => {
 		let config = require('./newConfig');
 		let comparisonResults = await new comparePdf(config)
@@ -15,8 +15,11 @@ const expect = chai.expect;
 
 	it('Should be able to override specific config property', async () => {
 		const ComparePdf = new comparePdf();
-		ComparePdf.config.paths.actualPdfRootFolder = process.cwd() + '/data/newActualPdfs';
-		let comparisonResults = await ComparePdf.actualPdfFile('newSame.pdf').baselinePdfFile('baseline.pdf').compare();
+		ComparePdf.config.paths.actualPdfRootFolder =
+			process.cwd() + '/data/newActualPdfs';
+		let comparisonResults = await ComparePdf.actualPdfFile('newSame.pdf')
+			.baselinePdfFile('baseline.pdf')
+			.compare();
 		expect(comparisonResults.status).to.equal('passed');
 	});
 
@@ -31,25 +34,30 @@ const expect = chai.expect;
 		);
 	});
 
-	['actualPngRootFolder', 'baselinePngRootFolder', 'diffPngRootFolder'].forEach((pngFolder) => {
-		it(`Should be able to throw error when config has missing ${pngFolder}`, async () => {
-			delete require.cache[require.resolve('./config')];
-			let missingConfig = require('./config');
-			missingConfig.paths[pngFolder] = '';
-			let comparisonResults = await new comparePdf(missingConfig)
-				.actualPdfFile('same')
-				.baselinePdfFile('baseline')
-				.compare();
+	['actualPngRootFolder', 'baselinePngRootFolder', 'diffPngRootFolder'].forEach(
+		(pngFolder) => {
+			it(`Should be able to throw error when config has missing ${pngFolder}`, async () => {
+				delete require.cache[require.resolve('./config')];
+				let missingConfig = require('./config');
+				missingConfig.paths[pngFolder] = '';
+				let comparisonResults = await new comparePdf(missingConfig)
+					.actualPdfFile('same')
+					.baselinePdfFile('baseline')
+					.compare();
 
-			expect(comparisonResults.status).to.equal('failed');
-			expect(comparisonResults.message).to.equal(
-				'PNG directory is not set. Please define correctly then try again.'
-			);
-		});
-	});
+				expect(comparisonResults.status).to.equal('failed');
+				expect(comparisonResults.message).to.equal(
+					'PNG directory is not set. Please define correctly then try again.'
+				);
+			});
+		}
+	);
 
 	it('Should be able to throw error when not passing actual pdf file path', async () => {
-		let comparisonResults = await new comparePdf().actualPdfFile('').baselinePdfFile('baseline.pdf').compare();
+		let comparisonResults = await new comparePdf()
+			.actualPdfFile('')
+			.baselinePdfFile('baseline.pdf')
+			.compare();
 		expect(comparisonResults.status).to.equal('failed');
 		expect(comparisonResults.message).to.equal(
 			'Actual pdf file path was not set. Please define correctly then try again.'
@@ -68,7 +76,10 @@ const expect = chai.expect;
 	});
 
 	it('Should be able to throw error when not passing baseline pdf file path', async () => {
-		let comparisonResults = await new comparePdf().actualPdfFile('same.pdf').baselinePdfFile('').compare();
+		let comparisonResults = await new comparePdf()
+			.actualPdfFile('same.pdf')
+			.baselinePdfFile('')
+			.compare();
 		expect(comparisonResults.status).to.equal('failed');
 		expect(comparisonResults.message).to.equal(
 			'Baseline pdf file path was not set. Please define correctly then try again.'
@@ -98,7 +109,7 @@ const expect = chai.expect;
 		}
 	});
 });
- 
+
 describe('Compare Pdf By Image Tests', () => {
 	const engines = ['native', 'graphicsMagick'];
 	for (const engine of engines) {
@@ -109,8 +120,6 @@ describe('Compare Pdf By Image Tests', () => {
 				delete require.cache[require.resolve('./config')];
 				config = require('./config');
 				config.settings.imageEngine = engine;
-
-
 			});
 
 			it('Should be able to verify same single page PDFs', async () => {
@@ -166,14 +175,17 @@ describe('Compare Pdf By Image Tests', () => {
 				expect(comparisonResults.message).to.equal(
 					'Actual pdf page count (1) is not the same as Baseline pdf (2).'
 				);
-				
 			});
 
 			it('Should be able to verify same PDFs using direct buffer', async () => {
-				const actualPdfFilename = "same.pdf";
-				const baselinePdfFilename = "baseline.pdf";
-				const actualPdfBuffer = fs.readFileSync(`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`);
-				const baselinePdfBuffer = fs.readFileSync(`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`);
+				const actualPdfFilename = 'same.pdf';
+				const baselinePdfFilename = 'baseline.pdf';
+				const actualPdfBuffer = fs.readFileSync(
+					`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`
+				);
+				const baselinePdfBuffer = fs.readFileSync(
+					`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`
+				);
 
 				let comparisonResults = await new comparePdf()
 					.actualPdfBuffer(actualPdfBuffer, actualPdfFilename)
@@ -183,10 +195,14 @@ describe('Compare Pdf By Image Tests', () => {
 			});
 
 			it('Should be able to verify same PDFs using direct buffer passing filename in another way', async () => {
-				const actualPdfFilename = "same.pdf";
-				const baselinePdfFilename = "baseline.pdf";
-				const actualPdfBuffer = fs.readFileSync(`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`);
-				const baselinePdfBuffer = fs.readFileSync(`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`);
+				const actualPdfFilename = 'same.pdf';
+				const baselinePdfFilename = 'baseline.pdf';
+				const actualPdfBuffer = fs.readFileSync(
+					`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`
+				);
+				const baselinePdfBuffer = fs.readFileSync(
+					`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`
+				);
 
 				let comparisonResults = await new comparePdf()
 					.actualPdfBuffer(actualPdfBuffer)
@@ -198,10 +214,14 @@ describe('Compare Pdf By Image Tests', () => {
 			});
 
 			it('Should be able to verify different PDFs using direct buffer', async () => {
-				const actualPdfFilename = "notSame.pdf";
-				const baselinePdfFilename = "baseline.pdf";
-				const actualPdfBuffer = fs.readFileSync(`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`);
-				const baselinePdfBuffer = fs.readFileSync(`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`);
+				const actualPdfFilename = 'notSame.pdf';
+				const baselinePdfFilename = 'baseline.pdf';
+				const actualPdfBuffer = fs.readFileSync(
+					`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`
+				);
+				const baselinePdfBuffer = fs.readFileSync(
+					`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`
+				);
 
 				let comparisonResults = await new comparePdf()
 					.actualPdfBuffer(actualPdfBuffer, actualPdfFilename)
@@ -218,16 +238,25 @@ describe('Compare Pdf By Image Tests', () => {
 				let comparisonResults = await new comparePdf(config)
 					.actualPdfFile('same.pdf')
 					.baselinePdfFile('baseline.pdf')
-					.cropPage(1, { width: 530, height: 210, x: 0, y: 415 })
+					.cropPage(1, { 'width': 530, 'height': 210, 'x': 0, 'y': 415 })
 					.compare();
 				expect(comparisonResults.status).to.equal('passed');
 			});
 
 			it('Should be able to verify same PDFs with Multiple Croppings', async () => {
 				let croppings = [
-					{ pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 265 } },
-					{ pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 520 } },
-					{ pageIndex: 1, coordinates: { width: 530, height: 210, x: 0, y: 415 } }
+					{
+						'pageIndex': 0,
+						'coordinates': { 'width': 210, 'height': 180, 'x': 615, 'y': 265 }
+					},
+					{
+						'pageIndex': 0,
+						'coordinates': { 'width': 210, 'height': 180, 'x': 615, 'y': 520 }
+					},
+					{
+						'pageIndex': 1,
+						'coordinates': { 'width': 530, 'height': 210, 'x': 0, 'y': 415 }
+					}
 				];
 
 				let comparisonResults = await new comparePdf(config)
@@ -242,16 +271,22 @@ describe('Compare Pdf By Image Tests', () => {
 				let comparisonResults = await new comparePdf(config)
 					.actualPdfFile('maskedSame.pdf')
 					.baselinePdfFile('baseline.pdf')
-					.addMask(1, { x0: 20, y0: 40, x1: 100, y1: 70 })
-					.addMask(1, { x0: 330, y0: 40, x1: 410, y1: 70 })
+					.addMask(1, { 'x0': 20, 'y0': 40, 'x1': 100, 'y1': 70 })
+					.addMask(1, { 'x0': 330, 'y0': 40, 'x1': 410, 'y1': 70 })
 					.compare();
 				expect(comparisonResults.status).to.equal('passed');
 			});
 
 			it('Should be able to verify different PDFs with Masks', async () => {
 				let masks = [
-					{ pageIndex: 1, coordinates: { x0: 20, y0: 40, x1: 100, y1: 70 } },
-					{ pageIndex: 1, coordinates: { x0: 330, y0: 40, x1: 410, y1: 70 } }
+					{
+						'pageIndex': 1,
+						'coordinates': { 'x0': 20, 'y0': 40, 'x1': 100, 'y1': 70 }
+					},
+					{
+						'pageIndex': 1,
+						'coordinates': { 'x0': 330, 'y0': 40, 'x1': 410, 'y1': 70 }
+					}
 				];
 				let comparisonResults = await new comparePdf(config)
 					.actualPdfFile('maskedNotSame.pdf')
@@ -311,10 +346,14 @@ describe('Compare Pdf By Base64 Tests', () => {
 	});
 
 	it('Should be able to verify same PDFs using direct buffer', async () => {
-		const actualPdfFilename = "same.pdf";
-		const baselinePdfFilename = "baseline.pdf";
-		const actualPdfBuffer = fs.readFileSync(`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`);
-		const baselinePdfBuffer = fs.readFileSync(`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`);
+		const actualPdfFilename = 'same.pdf';
+		const baselinePdfFilename = 'baseline.pdf';
+		const actualPdfBuffer = fs.readFileSync(
+			`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`
+		);
+		const baselinePdfBuffer = fs.readFileSync(
+			`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`
+		);
 
 		let comparisonResults = await new comparePdf(config)
 			.actualPdfBuffer(actualPdfBuffer, actualPdfFilename)
@@ -335,10 +374,14 @@ describe('Compare Pdf By Base64 Tests', () => {
 	});
 
 	it('Should be able to verify different PDFs using direct buffer', async () => {
-		const actualPdfFilename = "notSame.pdf";
-		const baselinePdfFilename = "baseline.pdf";
-		const actualPdfBuffer = fs.readFileSync(`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`);
-		const baselinePdfBuffer = fs.readFileSync(`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`);
+		const actualPdfFilename = 'notSame.pdf';
+		const baselinePdfFilename = 'baseline.pdf';
+		const actualPdfBuffer = fs.readFileSync(
+			`${config.paths.actualPdfRootFolder}/${actualPdfFilename}`
+		);
+		const baselinePdfBuffer = fs.readFileSync(
+			`${config.paths.baselinePdfRootFolder}/${baselinePdfFilename}`
+		);
 
 		let comparisonResults = await new comparePdf(config)
 			.actualPdfBuffer(actualPdfBuffer, actualPdfFilename)
@@ -357,45 +400,69 @@ describe('Compare Pdf Image Opts', () => {
 
 	it('Should be able to set image opts', async () => {
 		let croppings = [
-			{ pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 265 } },
-			{ pageIndex: 0, coordinates: { width: 210, height: 180, x: 615, y: 520 } },
-			{ pageIndex: 1, coordinates: { width: 530, height: 210, x: 0, y: 415 } }
+			{
+				'pageIndex': 0,
+				'coordinates': { 'width': 210, 'height': 180, 'x': 615, 'y': 265 }
+			},
+			{
+				'pageIndex': 0,
+				'coordinates': { 'width': 210, 'height': 180, 'x': 615, 'y': 520 }
+			},
+			{
+				'pageIndex': 1,
+				'coordinates': { 'width': 530, 'height': 210, 'x': 0, 'y': 415 }
+			}
 		];
 
 		comparePdfUT = await new comparePdf(config)
 			.actualPdfFile('maskedSame.pdf')
 			.baselinePdfFile('baseline.pdf')
 			.cropPages(croppings)
-			.addMask(1, { x0: 20, y0: 40, x1: 100, y1: 70 })
-			.addMask(1, { x0: 330, y0: 40, x1: 410, y1: 70 })
+			.addMask(1, { 'x0': 20, 'y0': 40, 'x1': 100, 'y1': 70 })
+			.addMask(1, { 'x0': 330, 'y0': 40, 'x1': 410, 'y1': 70 })
 			.onlyPageIndexes([0])
 			.skipPageIndexes([1]);
 		expect(comparePdfUT.opts).to.eql({
-			masks: [
-				{ pageIndex: 1, coordinates: { x0: 20, y0: 40, x1: 100, y1: 70 }, color: 'black' },
-				{ pageIndex: 1, coordinates: { x0: 330, y0: 40, x1: 410, y1: 70 }, color: 'black' }
+			'masks': [
+				{
+					'pageIndex': 1,
+					'coordinates': { 'x0': 20, 'y0': 40, 'x1': 100, 'y1': 70 },
+					'color': 'black'
+				},
+				{
+					'pageIndex': 1,
+					'coordinates': { 'x0': 330, 'y0': 40, 'x1': 410, 'y1': 70 },
+					'color': 'black'
+				}
 			],
-			crops: croppings,
-			onlyPageIndexes: [0],
-			skipPageIndexes: [1]
-		})
+			'crops': croppings,
+			'onlyPageIndexes': [0],
+			'skipPageIndexes': [1]
+		});
 	});
 
 	it('Should be able to get different set of opts', async () => {
 		comparePdfUT = await new comparePdf(config)
 			.actualPdfFile('maskedSame.pdf')
 			.baselinePdfFile('baseline.pdf')
-			.cropPage(1, { width: 530, height: 210, x: 0, y: 415 })
-			.addMask(1, { x0: 20, y0: 40, x1: 100, y1: 70 });
+			.cropPage(1, { 'width': 530, 'height': 210, 'x': 0, 'y': 415 })
+			.addMask(1, { 'x0': 20, 'y0': 40, 'x1': 100, 'y1': 70 });
 		expect(comparePdfUT.opts).to.eql({
-			masks: [
-				{ pageIndex: 1, coordinates: { x0: 20, y0: 40, x1: 100, y1: 70 }, color: 'black' },
+			'masks': [
+				{
+					'pageIndex': 1,
+					'coordinates': { 'x0': 20, 'y0': 40, 'x1': 100, 'y1': 70 },
+					'color': 'black'
+				}
 			],
-			crops: [
-				{ pageIndex: 1, coordinates: { width: 530, height: 210, x: 0, y: 415 } }
+			'crops': [
+				{
+					'pageIndex': 1,
+					'coordinates': { 'width': 530, 'height': 210, 'x': 0, 'y': 415 }
+				}
 			],
-			onlyPageIndexes: [],
-			skipPageIndexes: []
-		})
+			'onlyPageIndexes': [],
+			'skipPageIndexes': []
+		});
 	});
 });

--- a/test/config.js
+++ b/test/config.js
@@ -1,20 +1,20 @@
 module.exports = {
-	paths: {
-		actualPdfRootFolder: process.cwd() + '/data/actualPdfs',
-		baselinePdfRootFolder: process.cwd() + '/data/baselinePdfs',
-		actualPngRootFolder: process.cwd() + '/data/actualPngs',
-		baselinePngRootFolder: process.cwd() + '/data/baselinePngs',
-		diffPngRootFolder: process.cwd() + '/data/diffPngs'
+	'paths': {
+		'actualPdfRootFolder': process.cwd() + '/data/actualPdfs',
+		'baselinePdfRootFolder': process.cwd() + '/data/baselinePdfs',
+		'actualPngRootFolder': process.cwd() + '/data/actualPngs',
+		'baselinePngRootFolder': process.cwd() + '/data/baselinePngs',
+		'diffPngRootFolder': process.cwd() + '/data/diffPngs'
 	},
-	settings: {
-		imageEngine: 'graphicsMagick',
-		density: 100,
-		quality: 70,
-		tolerance: 0,
-		threshold: 0.05,
-		cleanPngPaths: false,
-		matchPageCount: true,
-		disableFontFace: true,
-		verbosity: 0
+	'settings': {
+		'imageEngine': 'graphicsMagick',
+		'density': 100,
+		'quality': 70,
+		'tolerance': 0,
+		'threshold': 0.05,
+		'cleanPngPaths': false,
+		'matchPageCount': true,
+		'disableFontFace': true,
+		'verbosity': 0
 	}
 };

--- a/test/newConfig.js
+++ b/test/newConfig.js
@@ -1,20 +1,20 @@
 module.exports = {
-	paths: {
-		actualPdfRootFolder: process.cwd() + '/data/newActualPdfs',
-		baselinePdfRootFolder: process.cwd() + '/data/baselinePdfs',
-		actualPngRootFolder: process.cwd() + '/data/actualPngs',
-		baselinePngRootFolder: process.cwd() + '/data/baselinePngs',
-		diffPngRootFolder: process.cwd() + '/data/diffPngs'
+	'paths': {
+		'actualPdfRootFolder': process.cwd() + '/data/newActualPdfs',
+		'baselinePdfRootFolder': process.cwd() + '/data/baselinePdfs',
+		'actualPngRootFolder': process.cwd() + '/data/actualPngs',
+		'baselinePngRootFolder': process.cwd() + '/data/baselinePngs',
+		'diffPngRootFolder': process.cwd() + '/data/diffPngs'
 	},
-	settings: {
-		imageEngine: 'graphicsMagick',
-		density: 100,
-		quality: 70,
-		tolerance: 0,
-		threshold: 0.05,
-		cleanPngPaths: true,
-		matchPageCount: true,
-		disableFontFace: true,
-		verbosity: 0
+	'settings': {
+		'imageEngine': 'graphicsMagick',
+		'density': 100,
+		'quality': 70,
+		'tolerance': 0,
+		'threshold': 0.05,
+		'cleanPngPaths': true,
+		'matchPageCount': true,
+		'disableFontFace': true,
+		'verbosity': 0
 	}
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
-  "compilerOptions": {
-    "baseUrl": "./",
-    "declaration": true,
-    "esModuleInterop": true,
-    "module": "commonjs",
-    "paths": {
-      "*": ["@types/*"]
-    },
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "esnext",
-    "typeRoots": ["node_modules/@types", "@types", "types"]
-  },
-  "files": ["types/comparePdf.d.ts"],
-  "include": ["functions/**/*", "types/**/*"]
+	"compilerOptions": {
+		"baseUrl": "./",
+		"declaration": true,
+		"esModuleInterop": true,
+		"module": "commonjs",
+		"paths": {
+			"*": ["@types/*"]
+		},
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"target": "esnext",
+		"typeRoots": ["node_modules/@types", "@types", "types"]
+	},
+	"files": ["types/comparePdf.d.ts"],
+	"include": ["functions/**/*", "types/**/*"]
 }

--- a/tsconfig.testing.json
+++ b/tsconfig.testing.json
@@ -1,26 +1,17 @@
 {
-  "compilerOptions": {
-    "baseUrl": "./",
-    "declaration": true,
-    "esModuleInterop": true,
-    "module": "commonjs",
-    "paths": {
-      "*": [
-        "@types/*"
-      ]
-    },
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "esnext",
-    "typeRoots": [
-      "node_modules/@types",
-      "@types",
-      "types"
-    ],
-  },
-  "include": [
-    "functions/**/*",
-    "types/**/*"
-  ]
+	"compilerOptions": {
+		"baseUrl": "./",
+		"declaration": true,
+		"esModuleInterop": true,
+		"module": "commonjs",
+		"paths": {
+			"*": ["@types/*"]
+		},
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"target": "esnext",
+		"typeRoots": ["node_modules/@types", "@types", "types"]
+	},
+	"include": ["functions/**/*", "types/**/*"]
 }


### PR DESCRIPTION
added devDependency eslint v8.27.0
added devDependency eslint-config-prettier v8.5.0
added devDependency eslint-plugin-prettier v4.2.1
added devDependency lint-staged v13.0.3
added devDependency prettier v2.7.1
added devDependency husky v8.0.1
added .eslintrc.json configuration
added .prettierignore configuration
added .prettierrc.json configuration
added dependency typescript v4.8.4
updated devDepdency mocha to v10.1.0
updated .gitignore to ignore hushky folder
updated dependency fs-extra to v10.1.0
updated dependency gm to v1.25.0
updated dependency lodash to v4.17.21
updated dependency pdfjs-dist to v3.0.279
updated dependency pngjs to v6.0.0

used path.resolve to ensure paths remain consistent on linux/win32 platforms removed comment to use 32bit version of GhostScript from README.md as you can now use either added ImageMagick v7+ as dependency