### PR TITLE
Make PDF differences PNG output optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The config also contains settings for image comparison such as density, quality,
         cleanPngPaths: true,
         matchPageCount: true,
         disableFontFace: true,
-	    verbosity: 0,
+        verbosity: 0,
         outputPngDifferences: true
     }
 }

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The config also contains settings for image comparison such as density, quality,
         cleanPngPaths: true,
         matchPageCount: true,
         disableFontFace: true,
-	    verbosity: 0
+	    verbosity: 0,
+        outputPngDifferences: true
     }
 }
 ```
@@ -65,7 +66,7 @@ The config also contains settings for image comparison such as density, quality,
 -   **matchPageCount**: This is a boolean flag that enables or disables the page count verification between the actual and baseline pdfs
 -   **disableFontFace**: By default fonts are converted to OpenType fonts and loaded via the Font Loading API or `@font-face` rules. If disabled, fonts will be rendered using a built-in font renderer that constructs the glyphs with primitive path commands.
 -   **verbosity**: Controls the logging level for pdfjsLib (0: Errors (default), 1: Warning, 5: Infos)
-
+-   **outputPngDifferences**: Controls if PNG images showing differences are generated. In cases where output isn't needed, set to false (such as end-to-end tests).
 
 **Image Comparison**
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The config also contains settings for image comparison such as density, quality,
 -   **verbosity**: Controls the logging level for pdfjsLib (0: Errors (default), 1: Warning, 5: Infos)
 -   **outputPngDifferences**: Controls if PNG images showing differences are generated. In cases where output isn't needed, set to false (such as end-to-end tests).
 
+
 **Image Comparison**
 
 -   **tolerance**: This is the allowable pixel count that is different between the compared images.

--- a/functions/compareImages.js
+++ b/functions/compareImages.js
@@ -21,7 +21,9 @@ const comparePngs = async (actual, baseline, diff, config) => {
 			});
 
 			if (numDiffPixels > tolerance) {
-				fs.writeFileSync(diff, PNG.sync.write(diffPng));
+				if (config.outputPngDifferences) {
+					fs.writeFileSync(diff, PNG.sync.write(diffPng));
+				}
 				resolve({ status: 'failed', numDiffPixels: numDiffPixels, diffPng: diff });
 			} else {
 				resolve({ status: 'passed' });

--- a/functions/config.js
+++ b/functions/config.js
@@ -15,6 +15,7 @@ module.exports = {
 		cleanPngPaths: true,
 		matchPageCount: true,
 		disableFontFace: true,
-		verbosity: 0
+		verbosity: 0,
+		outputPngDifferences: true
 	}
 };


### PR DESCRIPTION
PDFs that have differences when using the `byImage` comparison will output a PNG into a `data` folder.  The outputting of PNGs should be optional.  An example use case is when running tests you only care if two PDFs are identical, and need a true/false response (but don't need the actual differences).  Using `byBase64` doesn't work because two PDFs can be identical but have different `base64` representations (different creation date or file name for example).