### PR TITLE
Results interface should be exported

### DIFF
--- a/types/comparePdf.d.ts
+++ b/types/comparePdf.d.ts
@@ -61,7 +61,7 @@ export interface Details {
     diffPng: string;
 }
 
-interface Results {
+export interface Results {
     status: string;
     message: string;
     details?: Details;


### PR DESCRIPTION
The `Results` interface should be exported.