### PR TITLE
Update comparePdf.d.ts to fix compare and ...Buffer function signatures

### DIFF
--- a/types/comparePdf.d.ts
+++ b/types/comparePdf.d.ts
@@ -1,6 +1,6 @@
 export as namespace ComparePdf;
 
-export = ComparePdf;
+export default ComparePdf;
 
 export interface ComparePdfConfig {
     paths: {
@@ -64,7 +64,7 @@ export interface Details {
 interface Results {
     status: string;
     message: string;
-    details?: Details;
+    details?: Details[];
 }
 
 declare class ComparePdf {
@@ -92,5 +92,5 @@ declare class ComparePdf {
 
     cropPages(cropPagesList: PageCrop[]): ComparePdf;
 
-    compare(comparisonType?: string): Results;
+    compare(comparisonType?: string): Promise<Results>;
 }


### PR DESCRIPTION
Fixes #33

This fixes several issues defined in the issue #33:
- compare function return type
- export default
- Results.details as array of Details