### PR TITLE
Add settings for set diffs colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ The config also contains settings for image comparison such as density, quality,
         cleanPngPaths: true,
         matchPageCount: true,
         disableFontFace: true,
-	    verbosity: 0
+	    verbosity: 0,
+        diffColor: [255, 0, 0],
+        diffColorAlt: null
     }
 }
 ```
@@ -65,6 +67,8 @@ The config also contains settings for image comparison such as density, quality,
 -   **matchPageCount**: This is a boolean flag that enables or disables the page count verification between the actual and baseline pdfs
 -   **disableFontFace**: By default fonts are converted to OpenType fonts and loaded via the Font Loading API or `@font-face` rules. If disabled, fonts will be rendered using a built-in font renderer that constructs the glyphs with primitive path commands.
 -   **verbosity**: Controls the logging level for pdfjsLib (0: Errors (default), 1: Warning, 5: Infos)
+-   **diffColor**: (from pixelmatch) The color of differing pixels in the diff output in [R, G, B] format. [255, 0, 0] by default.
+-   **diffColorAlt**: (from pixelmatch) An alternative color to use for dark on light differences to differentiate between "added" and "removed" parts. If not provided, all differing pixels use the color specified by diffColor. null by default.
 
 
 **Image Comparison**

--- a/functions/compareImages.js
+++ b/functions/compareImages.js
@@ -15,9 +15,13 @@ const comparePngs = async (actual, baseline, diff, config) => {
 
 			let threshold = config.settings && config.settings.threshold ? config.settings.threshold : 0.05;
 			let tolerance = config.settings && config.settings.tolerance ? config.settings.tolerance : 0;
+			let diffColor = config.settings && config.settings.diffColor ? config.settings.diffColor : [255, 0, 0];
+			let diffColorAlt = config.settings && config.settings.diffColorAlt ? config.settings.diffColorAlt : null;
 
 			let numDiffPixels = pixelmatch(actualPng.data, baselinePng.data, diffPng.data, width, height, {
-				threshold: threshold
+				threshold: threshold,
+				diffColor: diffColor,
+				diffColorAlt: diffColorAlt
 			});
 
 			if (numDiffPixels > tolerance) {

--- a/functions/config.js
+++ b/functions/config.js
@@ -15,6 +15,8 @@ module.exports = {
 		cleanPngPaths: true,
 		matchPageCount: true,
 		disableFontFace: true,
-		verbosity: 0
+		verbosity: 0,
+		diffColor: [255, 0, 0],
+    diffColorAlt: null
 	}
 };

--- a/test/config.js
+++ b/test/config.js
@@ -15,6 +15,8 @@ module.exports = {
 		cleanPngPaths: false,
 		matchPageCount: true,
 		disableFontFace: true,
-		verbosity: 0
+		verbosity: 0,
+		diffColor: [255, 0, 0],
+    diffColorAlt: null
 	}
 };

--- a/test/newConfig.js
+++ b/test/newConfig.js
@@ -15,6 +15,8 @@ module.exports = {
 		cleanPngPaths: true,
 		matchPageCount: true,
 		disableFontFace: true,
-		verbosity: 0
+		verbosity: 0,
+		diffColor: [255, 0, 0],
+    diffColorAlt: null
 	}
 };

--- a/types/comparePdf.d.ts
+++ b/types/comparePdf.d.ts
@@ -20,6 +20,8 @@ export interface ComparePdfConfig {
         matchPageCount?: boolean;
         disableFontFace?: boolean;
         verbosity?: number | string;
+        diffColor?: [number, number, number];
+        diffColorAlt?: [number, number, number] | null;
     };
 }
 


### PR DESCRIPTION
This update allows you to choose the difference colors (between the original pixel positions and the new ones) which are 2 parameters provided by the pixelmatch library. This can be useful in order to have better readability of the differences.