### PR TITLE
update STANDARD_FONT_DATA_URL path

### DIFF
--- a/functions/engines/native.js
+++ b/functions/engines/native.js
@@ -5,7 +5,7 @@ const Canvas = require('canvas');
 
 const CMAP_URL = '../../node_modules/pdfjs-dist/cmaps/';
 const CMAP_PACKED = true;
-const STANDARD_FONT_DATA_URL = '../../node_modules/pdfjs-dist/standard_fonts/';
+const STANDARD_FONT_DATA_URL = './node_modules/pdfjs-dist/standard_fonts/';
 
 const pdfPageToPng = async (pdfDocument, pageNumber, filename, isSinglePage = false) => {
 	try {


### PR DESCRIPTION
this change will remove this warning:
`Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: Unable to load font data at: ../../node_modules/pdfjs-dist/standard_fonts/FoxitSans.pfb".`

Also fixes blank rendering for some pdfs when using native engine.

Had issues where the png for the pdf was not rendering the texts
![image](https://github.com/marcdacz/compare-pdf/assets/91035170/34fd0cef-3302-4b89-9e18-ae521cf2b721)
