### PR TITLE
Use @napi-rs/canvas in native engine to match pdfjs-dist

### DIFF
--- a/functions/engines/NodeCanvasFactory.js
+++ b/functions/engines/NodeCanvasFactory.js
@@ -1,4 +1,4 @@
-const Canvas = require("canvas");
+const Canvas = require("@napi-rs/canvas");
 const assert = require("assert").strict;
 
 class NodeCanvasFactory {

--- a/functions/engines/native.js
+++ b/functions/engines/native.js
@@ -1,7 +1,7 @@
 const NodeCanvasFactory = require("./NodeCanvasFactory");
 const fs = require("fs-extra");
 const path = require("path");
-const Canvas = require("canvas");
+const Canvas = require("@napi-rs/canvas");
 
 let pdfjsLibPromise;
 const getPdfjsLib = () => {
@@ -36,7 +36,7 @@ const pdfPageToPng = async (
 
   await page.render(renderContext).promise;
 
-  const image = canvasAndContext.canvas.toBuffer();
+  const image = canvasAndContext.canvas.toBuffer("image/png");
   const pngFileName = isSinglePage
     ? filename
     : filename.replace(".png", `-${pageNumber - 1}.png`);
@@ -85,7 +85,7 @@ const applyMask = async (
     coordinates.x1 - coordinates.x0,
     coordinates.y1 - coordinates.y0,
   );
-  fs.writeFileSync(pngFilePath, canvas.toBuffer());
+  fs.writeFileSync(pngFilePath, canvas.toBuffer("image/png"));
 };
 
 const applyCrop = async (
@@ -110,7 +110,7 @@ const applyCrop = async (
   );
   fs.writeFileSync(
     pngFilePath.replace(".png", `-${index}.png`),
-    canvas.toBuffer(),
+    canvas.toBuffer("image/png"),
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.1.10",
 			"license": "MIT",
 			"dependencies": {
+				"@napi-rs/canvas": "^0.1.65",
 				"canvas": "^3.1.0",
 				"fs-extra": "^11.2.0",
 				"gm": "^1.25.0",
@@ -303,6 +304,270 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@napi-rs/canvas": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+			"integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+			"license": "MIT",
+			"workspaces": [
+				"e2e/*"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas-android-arm64": "0.1.100",
+				"@napi-rs/canvas-darwin-arm64": "0.1.100",
+				"@napi-rs/canvas-darwin-x64": "0.1.100",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.100",
+				"@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+			}
+		},
+		"node_modules/@napi-rs/canvas-android-arm64": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+			"integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+			"integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-x64": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+			"integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+			"integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+			"integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+			"integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+			"integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+			"integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-musl": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+			"integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+			"cpu": [
+				"x64"
+			],
+			"libc": [
+				"musl"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+			"integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+			"integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -412,8 +677,7 @@
 			"version": "18.0.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
 			"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@types/pixelmatch": {
 			"version": "5.2.6",
@@ -455,7 +719,6 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1444,7 +1707,6 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -5408,6 +5670,90 @@
 				}
 			}
 		},
+		"@napi-rs/canvas": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+			"integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+			"requires": {
+				"@napi-rs/canvas-android-arm64": "0.1.100",
+				"@napi-rs/canvas-darwin-arm64": "0.1.100",
+				"@napi-rs/canvas-darwin-x64": "0.1.100",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.100",
+				"@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+			}
+		},
+		"@napi-rs/canvas-android-arm64": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+			"integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+			"optional": true
+		},
+		"@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+			"integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+			"optional": true
+		},
+		"@napi-rs/canvas-darwin-x64": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+			"integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+			"optional": true
+		},
+		"@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+			"integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+			"optional": true
+		},
+		"@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+			"integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+			"optional": true
+		},
+		"@napi-rs/canvas-linux-arm64-musl": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+			"integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+			"optional": true
+		},
+		"@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+			"integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+			"optional": true
+		},
+		"@napi-rs/canvas-linux-x64-gnu": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+			"integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+			"optional": true
+		},
+		"@napi-rs/canvas-linux-x64-musl": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+			"integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+			"optional": true
+		},
+		"@napi-rs/canvas-win32-arm64-msvc": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+			"integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+			"optional": true
+		},
+		"@napi-rs/canvas-win32-x64-msvc": {
+			"version": "0.1.100",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+			"integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+			"optional": true
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5502,8 +5848,7 @@
 			"version": "18.0.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
 			"integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@types/pixelmatch": {
 			"version": "5.2.6",
@@ -5539,8 +5884,7 @@
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -6232,7 +6576,6 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
 			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"ts-node": "latest"
 	},
 	"dependencies": {
+		"@napi-rs/canvas": "^0.1.65",
 		"canvas": "^3.1.0",
 		"fs-extra": "^11.2.0",
 		"gm": "^1.25.0",


### PR DESCRIPTION
Fixes #55.

`pdfjs-dist@4.x` uses `@napi-rs/canvas` in Node for its internal polyfills (`DOMMatrix`, `ImageData`, `Path2D`) and intermediate canvases (`pdf.mjs:11411-11443`, `pdf.mjs:11451-11456`). When the native engine hands pdfjs a Cairo-backed `canvas` v3 rendering context, the intermediate image objects pdfjs constructs fail `canvas`'s strict `instanceOf` type check inside `Context2d::DrawImage`, throwing `TypeError: Image or Canvas expected`. The error is then swallowed by `comparePdfByImage`'s outer `try/catch` and surfaces only as a generic `status: failed, message: "An error occurred."`.

Switching the native engine to `@napi-rs/canvas` so both sides of the boundary speak the same module fixes it. Same fix recommended by the pdf.js maintainers in mozilla/pdf.js#19566 and #19794.

### Changes

`functions/engines/NodeCanvasFactory.js`
- `require("canvas")` → `require("@napi-rs/canvas")`

`functions/engines/native.js`
- `require("canvas")` → `require("@napi-rs/canvas")`
- `canvas.toBuffer()` → `canvas.toBuffer("image/png")` (×3) — `@napi-rs/canvas` requires an explicit mime type.

`package.json`
- Adds `@napi-rs/canvas` as a direct dependency. Today it's installed indirectly via pdfjs-dist's `optionalDependencies`; declaring it directly makes the dependency explicit and guaranteed.

graphicsMagick engine unchanged. Public API and types unchanged.

### Verification

Self-compare of a PDF with embedded raster images:

- before: `{ status: "failed", message: "An error occurred.\nTypeError: Image or Canvas expected" }`
- after:  `{ status: "passed" }`

Local `npm test` against the modified branch passes all the native-engine specs that pass on master (the same 2 native specs and ~22 graphicsMagick specs fail on master too — appears to be environmental, e.g. GraphicsMagick/Ghostscript not installed on a Windows machine).

### Follow-up (optional)

`canvas` (Cairo v3) becomes unused after this change. Left in `dependencies` in this PR to keep the diff minimal — happy to drop it in a follow-up if you'd prefer.